### PR TITLE
Fix CPScannerViewRenderer formsView.IsScanning and formsView.IsAnalyzing checks

### DIFF
--- a/Source/CameraPreview.Droid/CPScannerViewRenderer.cs
+++ b/Source/CameraPreview.Droid/CPScannerViewRenderer.cs
@@ -40,10 +40,10 @@ namespace CameraPreview.Droid
                 nativeSurface.SurfaceTextureSizeChanged += NativeSurface_SurfaceTextureSizeChanged;
                 base.SetNativeControl(nativeSurface);
 
-                if (formsView.IsScanning)
+                if (!formsView.IsScanning)
                     nativeSurface.StartScanning(formsView.RaiseScanResult, formsView.Options);
 
-                if (!formsView.IsAnalyzing)
+                if (formsView.IsAnalyzing)
                     nativeSurface.PauseAnalysis();
             }
         }

--- a/Source/CameraPreview.iOS/CPScannerViewRenderer.cs
+++ b/Source/CameraPreview.iOS/CPScannerViewRenderer.cs
@@ -29,10 +29,10 @@ namespace CameraPreview.iOS
 
                 base.SetNativeControl(nativeView);
 
-                if (formsView.IsScanning)
+                if (!formsView.IsScanning)
                     nativeView.StartScanning(formsView.RaiseScanResult, formsView.Options);
 
-                if (!formsView.IsAnalyzing)
+                if (formsView.IsAnalyzing)
                     nativeView.PauseAnalysis();
             }
 


### PR DESCRIPTION
The old combination of if prevented the opening of the camera, particularly in iOS